### PR TITLE
Document  format "image/png; mode=8bit"

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Configuration format:
         }
         "extent": [xmin, ymin, xmax, ymax],         // optional custom extent which overrides extent from WMS capabilities
         "tiled": true,                              // optional, use tiled WMS (default is false)
-        "format": "image/png",                      // optional, the image format to use in the WMS request, defaults to image/png
+        "format": "image/png",                      // optional, the image format to use in the WMS request, defaults to image/png; other possible values "image/jpeg" or "image/png; mode=8bit" (1 bit or 16 bit modes also available for png)
         "backgroundLayers": [                       // optional background layers
           {
             "name": "<background layer name>",      // background layer name from list below

--- a/themesConfig.json
+++ b/themesConfig.json
@@ -5,7 +5,7 @@
         "url": "https://services.geo.zg.ch/ows/BasisplanSW",
         "attribution": "Kanton Zug",
         "attributionUrl": "https://www.zg.ch/behoerden/direktion-des-innern/geoportal",
-        "format": "image/png;mode=8bit",
+        "format": "image/png; mode=8bit",
         "default": true,
         "scales": [200000, 80000, 40000, 20000, 10000, 8000, 6000, 4000, 2000, 1000, 500, 250, 100],
         "backgroundLayers": [
@@ -23,7 +23,7 @@
         "url": "http://qwc2.sourcepole.ch/wms/wolfsburg/qwc2_demo",
         "attribution": "Stadt Wolfsburg",
         "attributionUrl": "https://geoportal.stadt.wolfsburg.de/",
-        "format": "image/png;mode=8bit",
+        "format": "image/png; mode=8bit",
         "default": true,
         "scales": [200000, 80000, 40000, 20000, 10000, 8000, 6000, 4000, 2000, 1000, 500, 250, 100],
         "backgroundLayers": [

--- a/translations/tsconfig.json
+++ b/translations/tsconfig.json
@@ -3,7 +3,8 @@
     "de-DE",
     "en-US",
     "fr-FR",
-    "it-IT"
+    "it-IT",
+    "ro-RO"
     ],
     "strings": [
     ]


### PR DESCRIPTION
Hi,
I noticed that the current settings only output default png as the png 8bit (16 and 1 bit) modes need a space in order to work:

``"image/png; mode=8bit"`` instead of ``"image/png;mode=8bit``.

This fixes the default demo and also documents the possible options + small Ro fix.