### PR TITLE
improve default styling to be more eye friendly

### DIFF
--- a/styleConfig.js
+++ b/styleConfig.js
@@ -16,7 +16,7 @@ let styleConfig = {
   titlebar_bg: "#595959",
   titlebar_fg: "white",
   // Messagebar
-  messagebar_bg: "#fcd5b5",
+  messagebar_bg: "#eeeeee",
   // Top and bottom panels
   panel_bg: "rgba(255,255, 255, 0.75)",
   panel_fg: "#595959",


### PR DESCRIPTION
The current default styling for the tools doesn't look that good:
![wrong](https://user-images.githubusercontent.com/3179646/30318819-d0e484c0-97b6-11e7-878a-2bcd83c6de3f.png)

This makes the styling looking more connected:

![good](https://user-images.githubusercontent.com/3179646/30318887-0401c458-97b7-11e7-8bad-c9c0cf4805aa.png)
