### PR TITLE
Use valid JSON in themesConfig.json

### DIFF
--- a/themesConfig.json
+++ b/themesConfig.json
@@ -36,7 +36,7 @@
         "searchProviders": ["coordinates", "uster"],
         "mapCrs": "EPSG:3857",
         "additionalMouseCrs": ["EPSG:21781", "EPSG:2056"]
-      },
+      }
     ],
     "groups": [
       {


### PR DESCRIPTION
yarn run prod currently fails with the following error:

    SyntaxError: /home/paggf/qwc2-demo-app/themesConfig.json: Unexpected token ] in JSON at position 1416

This commit fixes the issue.