### PR TITLE
Added trouble shooting on Ubuntu 18.04

### DIFF
--- a/doc/QWC2_Documentation.md
+++ b/doc/QWC2_Documentation.md
@@ -34,6 +34,15 @@ Next, install all required dependencies:
     $ cd qwc2-demo-app
     $ yarn install
 
+If you face a problem installing it on Ubuntu.
+
+    $ sudo apt remove cmdtest
+    $ sudo apt remove yarn
+    $ curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+    $ echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+    $ sudo apt-get update  
+    $ sudo apt-get install yarn
+
 Then, start a local development application:
 
     $ yarn start


### PR DESCRIPTION
While trying to install the project on ubuntu I faced a problem and yarn would complain

00h00m00s 0/0: : ERROR: [Errno 2] No such file or directory: 'install'

The problem was fixed by reinstalling yarn from their repo.

I have added the same to the quickstart documentation