### PR TITLE
Use the SHA-256 hash function

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,6 +17,7 @@ module.exports = (env, argv) => {
             App: path.resolve(__dirname, 'js', 'app.jsx')
         },
         output: {
+            hashFunction: 'sha256',
             path: path.resolve(__dirname, 'prod')
         },
         watchOptions: {


### PR DESCRIPTION
An `ERR_OSSL_EVP_UNSUPPORTED` error is thrown when running
`npm run build` on Node.js 17. This happens because, by default, the
MD4 hash function is used and this algorithm is no longer supported by
OpenSSL 3, included in Node.js 17.