### PR TITLE
Fix generated map thumbnails path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ prod/
 icons/build
 npm-debug.log
 themes.json
-assets/img/genmapthumbs/*
+static/assets/img/genmapthumbs/*
 yarn-error.log


### PR DESCRIPTION
Generated map thumbnails are now stored in
`static/assets/img/genmapthumbs/`.