### PR TITLE
correct structure of example in documentation

### DIFF
--- a/doc/src/qwc_configuration.md
+++ b/doc/src/qwc_configuration.md
@@ -213,20 +213,20 @@ The second step is to configure the themes which are available to QWC2 in the `t
             "groups": [ { <Group> }, ...]
            },
            ...
-        ]
+        ],
+        "externalLayers": [
+          { <ExternalLayerDefinition> },
+          ...
+        ],
+        "themeInfoLinks": [
+          { <ThemeInfoLinkDefinition> },
+          ...
+        ],
+        "backgroundLayers": [
+          { <BackgroundLayerDefinition> },
+          ...
+        ],
       },
-      "externalLayers": [
-        { <ExternalLayerDefinition> },
-        ...
-      ],
-      "themeInfoLinks": [
-        { <ThemeInfoLinkDefinition> },
-        ...
-      ],
-      "backgroundLayers": [
-        { <BackgroundLayerDefinition> },
-        ...
-      ],
       "defaultScales": [<Scale denominators>],
       "defaultPrintScales" [<Scale denominators>],
       "defaultPrintResolutions": [<DPIs>],


### PR DESCRIPTION
The structure of the themesConfig.json in the documentation differs slightly from the sample themesConfig.json. This PR corrects this. 

Following the structure in the sample themesConfig.json everything is fine, following the structure in the documentation leads to the following error:
.../scripts/themesConfig.js:638
      throw error;
      ^
TypeError: Cannot read properties of undefined (reading 'map')
    at genThemes (.../scripts/themesConfig.js:568:62)
    at .../scripts/themesConfig.js:634:5

Node.js v18.16.0
error Command failed with exit code 1.
Fix #441
