### PR TITLE
Request GetFeatureInfo without bbox

### DIFF
--- a/js/SearchProviders.js
+++ b/js/SearchProviders.js
@@ -204,13 +204,11 @@ class QgisSearch {
 
         const filter = {...searchParams.cfgParams.expression};
         const values = {TEXT: text};
-        const bbox = CoordinatesUtils.reprojectBbox(searchParams.theme.bbox.bounds, searchParams.theme.bbox.crs, searchParams.theme.mapCrs);
         const params = {
             SERVICE: 'WMS',
             VERSION: searchParams.theme.version,
             REQUEST: 'GetFeatureInfo',
             CRS: searchParams.theme.mapCrs,
-            BBOX: bbox.join(","),
             WIDTH: 100,
             HEIGHT: 100,
             LAYERS: [],


### PR DESCRIPTION
Hi,

As `BBOX` parameter is not a required parameter in `GetFeatureInfo`, I would delete this parameter for the Qgis search provider. What do you think about it ?

Sometimes, I don't have any results because I think that features are not visible due to the scale according to the scale of theme bounds.

Maybe it is something to also do in QWC2 plugin `FeatureSearch` ?

Thanks