### PR TITLE
Update qwc2 and config

### DIFF
--- a/js/appConfig.js
+++ b/js/appConfig.js
@@ -18,7 +18,6 @@ import BookmarkPlugin from 'qwc2/plugins/Bookmark';
 import BottomBarPlugin from 'qwc2/plugins/BottomBar';
 import CookiePopupPlugin from 'qwc2/plugins/CookiePopup';
 import CyclomediaPlugin from 'qwc2/plugins/Cyclomedia';
-import DxfExportPlugin from 'qwc2/plugins/DxfExport';
 import EditingPlugin from 'qwc2/plugins/Editing';
 import FeatureFormPlugin from 'qwc2/plugins/FeatureForm';
 import FeatureSearchPlugin from 'qwc2/plugins/FeatureSearch';
@@ -44,7 +43,6 @@ import NewsPopupPlugin from 'qwc2/plugins/NewsPopup';
 import PortalPlugin from 'qwc2/plugins/Portal';
 import PrintPlugin from 'qwc2/plugins/Print';
 import ProcessNotificationsPlugin from 'qwc2/plugins/ProcessNotifications';
-import RasterExportPlugin from 'qwc2/plugins/RasterExport';
 import RedliningPlugin from 'qwc2/plugins/Redlining';
 import ReportsPlugin from 'qwc2/plugins/Reports';
 import RoutingPlugin from 'qwc2/plugins/Routing';
@@ -96,7 +94,6 @@ export default {
             BottomBarPlugin: BottomBarPlugin,
             CookiePopupPlugin: CookiePopupPlugin,
             CyclomediaPlugin: CyclomediaPlugin,
-            DxfExportPlugin: DxfExportPlugin,
             EditingPlugin: EditingPlugin(/* CustomEditingInterface */),
             FeatureFormPlugin: FeatureFormPlugin(/* CustomEditingInterface */),
             GeometryDigitizerPlugin: GeometryDigitizerPlugin,
@@ -120,7 +117,6 @@ export default {
             PortalPlugin: PortalPlugin,
             PrintPlugin: PrintPlugin,
             ProcessNotificationsPlugin: ProcessNotificationsPlugin,
-            RasterExportPlugin: RasterExportPlugin,
             RedliningPlugin: RedliningPlugin({
                 BufferSupport: BufferSupport
             }),

--- a/static/config.json
+++ b/static/config.json
@@ -287,6 +287,7 @@
       {
         "name": "Print",
         "cfg": {
+          "displayPrintSeries": true,
           "inlinePrintOutput": false,
           "printExternalLayers": true,
           "gridInitiallyEnabled": false,

--- a/static/translations/cs-CZ.json
+++ b/static/translations/cs-CZ.json
@@ -11,14 +11,12 @@
         "MapExport": "Export mapu",
         "MapFilter": "",
         "Print": "Tisk",
-        "RasterExport": "Export rastru",
         "Reports": "",
         "Settings": "Nastavení",
         "Share": "Sdílet odkaz",
         "ThemeSwitcher": "Téma",
         "AttributeTable": "Atributy",
         "Cyclomedia": "Cyclomedia",
-        "DxfExport": "DXF Export",
         "FeatureForm": "Editační formulář",
         "FeatureSearch": "",
         "GeometryDigitizer": "",
@@ -140,11 +138,6 @@
       "login": "",
       "scalehint": "",
       "title": "Cyclomedia"
-    },
-    "dxfexport": {
-      "layers": "Vrstvy",
-      "selectinfo": "Vyberte oblast pro export...",
-      "symbologyscale": "Meřítko symbolů:"
     },
     "editing": {
       "add": "Přidat",
@@ -378,6 +371,10 @@
     },
     "print": {
       "atlasfeature": "",
+      "download": "",
+      "download_as_onepdf": "",
+      "download_as_onezip": "",
+      "download_as_single": "",
       "format": "Formát",
       "grid": "Mřížka:",
       "layout": "Rovržení:",
@@ -387,25 +384,18 @@
       "nolayouts": "Vybrané téma nepodporuje tisk",
       "notheme": "Není vybráno téma",
       "output": "",
+      "overlap": "",
       "pickatlasfeature": "",
       "resolution": "Rozlišení",
       "rotation": "Orientace",
       "save": "",
       "scale": "Měřítko",
+      "series": "",
       "submit": "Tisk",
       "wait": "Čekejte..."
     },
     "qtdesignerform": {
       "loading": ""
-    },
-    "rasterexport": {
-      "format": "Formát:",
-      "resolution": "Rozlišení:",
-      "scale": "Měřítko",
-      "size": "Velikost",
-      "submit": "Export",
-      "usersize": "Vybrat na mapě...",
-      "wait": "Čekejte..."
     },
     "redlining": {
       "border": "Okraj",

--- a/static/translations/de-CH.json
+++ b/static/translations/de-CH.json
@@ -11,14 +11,12 @@
         "MapExport": "Karte exportieren",
         "MapFilter": "Kartenfilter",
         "Print": "Drucken",
-        "RasterExport": "Raster-Export",
         "Reports": "Berichte",
         "Settings": "Einstellungen",
         "Share": "Teilen",
         "ThemeSwitcher": "Themen",
         "AttributeTable": "Attributtabelle",
         "Cyclomedia": "Cyclomedia",
-        "DxfExport": "DXF-Export",
         "FeatureForm": "Objektformular",
         "FeatureSearch": "Objektsuche",
         "GeometryDigitizer": "Geometriedigitalisierung",
@@ -140,11 +138,6 @@
       "login": "Anmelden",
       "scalehint": "Die Aufnahmen sind nur ab Massstab 1:{0} auf der Karte sichtbar.",
       "title": "Cyclomedia Viewer"
-    },
-    "dxfexport": {
-      "layers": "Ebenen",
-      "selectinfo": "Rechteck um die zu exportierende Region aufziehen",
-      "symbologyscale": "Darstellungsmassstab"
     },
     "editing": {
       "add": "Hinzufügen",
@@ -378,6 +371,10 @@
     },
     "print": {
       "atlasfeature": "Atlasobjekt",
+      "download": "",
+      "download_as_onepdf": "",
+      "download_as_onezip": "",
+      "download_as_single": "",
       "format": "Format",
       "grid": "Gitter",
       "layout": "Format",
@@ -387,25 +384,18 @@
       "nolayouts": "Das gewählte Thema stellt keine Druck-Vorlagen zur Verfügung.",
       "notheme": "Kein Thema selektiert",
       "output": "Druckausgabe",
+      "overlap": "",
       "pickatlasfeature": "In Ebene {0} auswählen...",
       "resolution": "Auflösung",
       "rotation": "Rotation",
       "save": "Speichern",
       "scale": "Massstab",
+      "series": "",
       "submit": "Erzeugen",
       "wait": "Bitte warten..."
     },
     "qtdesignerform": {
       "loading": "Formular wird geladen..."
-    },
-    "rasterexport": {
-      "format": "Format",
-      "resolution": "Auflösung",
-      "scale": "Massstab",
-      "size": "Dimensionen",
-      "submit": "Exportieren",
-      "usersize": "Auf Karte auswählen...",
-      "wait": "Bitte warten..."
     },
     "redlining": {
       "border": "Rand",

--- a/static/translations/de-DE.json
+++ b/static/translations/de-DE.json
@@ -11,14 +11,12 @@
         "MapExport": "Karte exportieren",
         "MapFilter": "Kartenfilter",
         "Print": "Drucken",
-        "RasterExport": "Raster-Export",
         "Reports": "Berichte",
         "Settings": "Einstellungen",
         "Share": "Teilen",
         "ThemeSwitcher": "Themen",
         "AttributeTable": "Attributtabelle",
         "Cyclomedia": "Cyclomedia",
-        "DxfExport": "DXF-Export",
         "FeatureForm": "Objektformular",
         "FeatureSearch": "Objektsuche",
         "GeometryDigitizer": "Geometriedigitalisierung",
@@ -140,11 +138,6 @@
       "login": "Anmelden",
       "scalehint": "Die Aufnahmen sind nur ab Maßstab 1:{0} auf der Karte sichtbar.",
       "title": "Cyclomedia Viewer"
-    },
-    "dxfexport": {
-      "layers": "Ebenen",
-      "selectinfo": "Rechteck um die zu exportierende Region aufziehen",
-      "symbologyscale": "Darstellungsmaßstab"
     },
     "editing": {
       "add": "Hinzufügen",
@@ -378,34 +371,31 @@
     },
     "print": {
       "atlasfeature": "Atlasobjekt",
+      "download": "Herunterladen",
+      "download_as_onepdf": "als ein PDF-Dokument",
+      "download_as_onezip": "als ein ZIP-Archiv",
+      "download_as_single": "als einzelne Dateien",
       "format": "Format",
       "grid": "Gitter",
-      "layout": "Format",
+      "layout": "Layout",
       "legend": "Legende",
       "maximize": "Maximieren",
       "minimize": "Minimieren",
       "nolayouts": "Das gewählte Thema stellt keine Druck-Vorlagen zur Verfügung.",
       "notheme": "Kein Thema selektiert",
       "output": "Druckausgabe",
+      "overlap": "Überlappung",
       "pickatlasfeature": "In Ebene {0} auswählen...",
       "resolution": "Auflösung",
       "rotation": "Rotation",
       "save": "Speichern",
       "scale": "Maßstab",
+      "series": "Seriendruck",
       "submit": "Erzeugen",
       "wait": "Bitte warten..."
     },
     "qtdesignerform": {
       "loading": "Formular wird geladen..."
-    },
-    "rasterexport": {
-      "format": "Format",
-      "resolution": "Auflösung",
-      "scale": "Maßstab",
-      "size": "Dimensionen",
-      "submit": "Exportieren",
-      "usersize": "Auf Karte auswählen...",
-      "wait": "Bitte warten..."
     },
     "redlining": {
       "border": "Rand",

--- a/static/translations/en-US.json
+++ b/static/translations/en-US.json
@@ -11,14 +11,12 @@
         "MapExport": "Export map",
         "MapFilter": "Map Filter",
         "Print": "Print",
-        "RasterExport": "Raster Export",
         "Reports": "Reports",
         "Settings": "Settings",
         "Share": "Share Link",
         "ThemeSwitcher": "Theme",
         "AttributeTable": "Attribute Table",
         "Cyclomedia": "Cyclomedia",
-        "DxfExport": "DXF Export",
         "FeatureForm": "Feature Form",
         "FeatureSearch": "Feature Search",
         "GeometryDigitizer": "Geometry digitizer",
@@ -140,11 +138,6 @@
       "login": "Login",
       "scalehint": "The recordings are only visible on the map below scale 1:{0}.",
       "title": "Cyclomedia Viewer"
-    },
-    "dxfexport": {
-      "layers": "Layers",
-      "selectinfo": "Drag a rectangle around the region to export...",
-      "symbologyscale": "Symbology scale"
     },
     "editing": {
       "add": "Add",
@@ -378,6 +371,10 @@
     },
     "print": {
       "atlasfeature": "Atlas feature",
+      "download": "Download",
+      "download_as_onepdf": "as one PDF document",
+      "download_as_onezip": "as one ZIP file",
+      "download_as_single": "as single files",
       "format": "Format",
       "grid": "Grid",
       "layout": "Layout",
@@ -387,25 +384,18 @@
       "nolayouts": "The selected theme does not support printing",
       "notheme": "No theme selected",
       "output": "Print output",
+      "overlap": "Overlap",
       "pickatlasfeature": "Pick in layer {0}...",
       "resolution": "Resolution",
       "rotation": "Rotation",
       "save": "Save",
       "scale": "Scale",
+      "series": "Print series",
       "submit": "Print",
       "wait": "Please wait..."
     },
     "qtdesignerform": {
       "loading": "Loading form..."
-    },
-    "rasterexport": {
-      "format": "Format",
-      "resolution": "Resolution",
-      "scale": "Scale",
-      "size": "Size",
-      "submit": "Export",
-      "usersize": "Select on map...",
-      "wait": "Please wait..."
     },
     "redlining": {
       "border": "Border",

--- a/static/translations/es-ES.json
+++ b/static/translations/es-ES.json
@@ -11,14 +11,12 @@
         "MapExport": "Exportar mapa",
         "MapFilter": "",
         "Print": "Imprimir",
-        "RasterExport": "Exportar trama",
         "Reports": "",
         "Settings": "Opciones",
         "Share": "Compartir enlace",
         "ThemeSwitcher": "Tema",
         "AttributeTable": "Tabla de Atributos",
         "Cyclomedia": "",
-        "DxfExport": "Exportar DXF",
         "FeatureForm": "Formulario de Elemento",
         "FeatureSearch": "",
         "GeometryDigitizer": "",
@@ -140,11 +138,6 @@
       "login": "",
       "scalehint": "",
       "title": ""
-    },
-    "dxfexport": {
-      "layers": "Capas",
-      "selectinfo": "Arrastre un rectángulo alrededor de la zona para exportar...",
-      "symbologyscale": "Escala de la simbología:"
     },
     "editing": {
       "add": "Añadir",
@@ -378,6 +371,10 @@
     },
     "print": {
       "atlasfeature": "",
+      "download": "",
+      "download_as_onepdf": "",
+      "download_as_onezip": "",
+      "download_as_single": "",
       "format": "Formato:",
       "grid": "Grilla:",
       "layout": "Diseño:",
@@ -387,25 +384,18 @@
       "nolayouts": "El tema seleccionado no admite su impresión",
       "notheme": "No hay tema seleccionado",
       "output": "Salida de impresión",
+      "overlap": "",
       "pickatlasfeature": "",
       "resolution": "Resolución",
       "rotation": "Rotación",
       "save": "",
       "scale": "Escala:",
+      "series": "",
       "submit": "Imprimir",
       "wait": "Por favor espere..."
     },
     "qtdesignerform": {
       "loading": "Cargando formulario..."
-    },
-    "rasterexport": {
-      "format": "Formato:",
-      "resolution": "Resolución:",
-      "scale": "",
-      "size": "",
-      "submit": "",
-      "usersize": "",
-      "wait": ""
     },
     "redlining": {
       "border": "Límite",

--- a/static/translations/fr-FR.json
+++ b/static/translations/fr-FR.json
@@ -11,14 +11,12 @@
         "MapExport": "Exporter la carte",
         "MapFilter": "Filtrer la carte",
         "Print": "Imprimer",
-        "RasterExport": "Exporter l'image",
         "Reports": "Rapports",
         "Settings": "Paramètres",
         "Share": "Partager",
         "ThemeSwitcher": "Thèmes",
         "AttributeTable": "Table d'attributs",
         "Cyclomedia": "Cyclomedia",
-        "DxfExport": "Export DXF",
         "FeatureForm": "Formulaire d'objet",
         "FeatureSearch": "Recherche objet",
         "GeometryDigitizer": "Digitalisation des géométries",
@@ -140,11 +138,6 @@
       "login": "Connexion",
       "scalehint": "Les enregistrements ne sont visibles que sur la carte sous l'échelle 1 :{0}.",
       "title": "Visualiseur Cyclomedia"
-    },
-    "dxfexport": {
-      "layers": "Couches",
-      "selectinfo": "Faites glisser un rectangle autour de la région à exporter..",
-      "symbologyscale": "Echelle"
     },
     "editing": {
       "add": "Ajouter",
@@ -378,6 +371,10 @@
     },
     "print": {
       "atlasfeature": "Objet atlas",
+      "download": "",
+      "download_as_onepdf": "",
+      "download_as_onezip": "",
+      "download_as_single": "",
       "format": "Format",
       "grid": "Grille",
       "layout": "Mise en page",
@@ -387,25 +384,18 @@
       "nolayouts": "Il n'y a pas de mise en page disponible pour le thème choisi.",
       "notheme": "Pas de thème sélectionné",
       "output": "Impression",
+      "overlap": "",
       "pickatlasfeature": "Choisir dans la couche {0}",
       "resolution": "Résolution",
       "rotation": "Rotation",
       "save": "Enregistrer",
       "scale": "Echelle",
+      "series": "",
       "submit": "Imprimer",
       "wait": "Veuillez patienter..."
     },
     "qtdesignerform": {
       "loading": "Chargement du formulaire..."
-    },
-    "rasterexport": {
-      "format": "Format",
-      "resolution": "Résolution",
-      "scale": "Echelle",
-      "size": "Dimension",
-      "submit": "Exporter",
-      "usersize": "Selectionner sur la carte...",
-      "wait": "Veuillez patienter..."
     },
     "redlining": {
       "border": "Bordure",

--- a/static/translations/it-IT.json
+++ b/static/translations/it-IT.json
@@ -11,14 +11,12 @@
         "MapExport": "Esporta mappa",
         "MapFilter": "Filta mappa",
         "Print": "Stampa",
-        "RasterExport": "Esporta su immagine",
         "Reports": "Rapporti",
         "Settings": "Impostazioni",
         "Share": "Condividi",
         "ThemeSwitcher": "Temi",
         "AttributeTable": "Tabella attributi",
         "Cyclomedia": "Cyclomedia",
-        "DxfExport": "Esporta su DXF",
         "FeatureForm": "Formulario oggetto",
         "FeatureSearch": "Ricerca oggetto",
         "GeometryDigitizer": "Digitalizzazione geometrie",
@@ -140,11 +138,6 @@
       "login": "Login",
       "scalehint": "Le registrazioni sono solo visibili sulla mappa a partire da una scala di 1:{0}.",
       "title": "Visualizzatore Cyclomedia"
-    },
-    "dxfexport": {
-      "layers": "Livelli",
-      "selectinfo": "Seleziona l'area da esportare",
-      "symbologyscale": "Scala per la simbologia"
     },
     "editing": {
       "add": "Aggiungi",
@@ -378,6 +371,10 @@
     },
     "print": {
       "atlasfeature": "Oggetto atlante",
+      "download": "",
+      "download_as_onepdf": "",
+      "download_as_onezip": "",
+      "download_as_single": "",
       "format": "Formato",
       "grid": "Griglia",
       "layout": "Layout",
@@ -387,25 +384,18 @@
       "nolayouts": "Nessun layout di stampa",
       "notheme": "Nessun tema selezionato",
       "output": "Stampa",
+      "overlap": "",
       "pickatlasfeature": "Seleziona nel livello {1}...",
       "resolution": "Risoluzione",
       "rotation": "Rotazione",
       "save": "Salva",
       "scale": "Scala",
+      "series": "",
       "submit": "Stampa",
       "wait": "Attendere..."
     },
     "qtdesignerform": {
       "loading": "Caricando formulario..."
-    },
-    "rasterexport": {
-      "format": "Formato",
-      "resolution": "Risoluzione",
-      "scale": "Scala",
-      "size": "Dimensione",
-      "submit": "Esporta",
-      "usersize": "Seleziona sulla mappa...",
-      "wait": "Attendere..."
     },
     "redlining": {
       "border": "Bordo",

--- a/static/translations/pl-PL.json
+++ b/static/translations/pl-PL.json
@@ -11,14 +11,12 @@
         "MapExport": "Eksportuj mapę",
         "MapFilter": "",
         "Print": "Drukuj",
-        "RasterExport": "Eksport Rastra",
         "Reports": "",
         "Settings": "",
         "Share": "Udostępnij Link",
         "ThemeSwitcher": "Motyw",
         "AttributeTable": "",
         "Cyclomedia": "",
-        "DxfExport": "Eksport DXF",
         "FeatureForm": "",
         "FeatureSearch": "",
         "GeometryDigitizer": "",
@@ -140,11 +138,6 @@
       "login": "",
       "scalehint": "",
       "title": ""
-    },
-    "dxfexport": {
-      "layers": "",
-      "selectinfo": "Narysuj prostokąt, określając obszar do eksportu...",
-      "symbologyscale": "Skala symbolizacji:"
     },
     "editing": {
       "add": "",
@@ -378,6 +371,10 @@
     },
     "print": {
       "atlasfeature": "",
+      "download": "",
+      "download_as_onepdf": "",
+      "download_as_onezip": "",
+      "download_as_single": "",
       "format": "Format",
       "grid": "Siatka",
       "layout": "Layout",
@@ -387,25 +384,18 @@
       "nolayouts": "Wybrany motyw nie umożliwia drukowania",
       "notheme": "Brak wybranego motywu",
       "output": "Drukuj output",
+      "overlap": "",
       "pickatlasfeature": "",
       "resolution": "Rozdzielczość",
       "rotation": "Obrót",
       "save": "",
       "scale": "Skala",
+      "series": "",
       "submit": "Drukuj",
       "wait": "Proszę czekać..."
     },
     "qtdesignerform": {
       "loading": ""
-    },
-    "rasterexport": {
-      "format": "Format:",
-      "resolution": "Rozdzielczość:",
-      "scale": "",
-      "size": "",
-      "submit": "",
-      "usersize": "",
-      "wait": ""
     },
     "redlining": {
       "border": "Obramowanie",

--- a/static/translations/pt-BR.json
+++ b/static/translations/pt-BR.json
@@ -11,14 +11,12 @@
         "MapExport": "Exportar mapa",
         "MapFilter": "",
         "Print": "Imprimir",
-        "RasterExport": "Exportar imagem",
         "Reports": "",
         "Settings": "Configurações",
         "Share": "Compartilhar link",
         "ThemeSwitcher": "Tema",
         "AttributeTable": "Tabela de atributos",
         "Cyclomedia": "Cyclomedia",
-        "DxfExport": "Exportar DXF",
         "FeatureForm": "Atributos da feição",
         "FeatureSearch": "Procurar feição",
         "GeometryDigitizer": "",
@@ -140,11 +138,6 @@
       "login": "Login",
       "scalehint": "Indicação de escala",
       "title": "Titulo"
-    },
-    "dxfexport": {
-      "layers": "Camada",
-      "selectinfo": "Arraste um retângulo ao redor da região para exportar",
-      "symbologyscale": "Escala de simbologia"
     },
     "editing": {
       "add": "Adicionar",
@@ -378,6 +371,10 @@
     },
     "print": {
       "atlasfeature": "Feições do atlas",
+      "download": "",
+      "download_as_onepdf": "",
+      "download_as_onezip": "",
+      "download_as_single": "",
       "format": "Formato",
       "grid": "Grade",
       "layout": "Layout",
@@ -387,25 +384,18 @@
       "nolayouts": "O tema selecionado não suporta impressão",
       "notheme": "Nenhum tema selecionado",
       "output": "Saída de impressão",
+      "overlap": "",
       "pickatlasfeature": "",
       "resolution": "Resolução",
       "rotation": "Rotação",
       "save": "",
       "scale": "Escala",
+      "series": "",
       "submit": "Imprimir",
       "wait": "Aguarde..."
     },
     "qtdesignerform": {
       "loading": "Carregando"
-    },
-    "rasterexport": {
-      "format": "Formato:",
-      "resolution": "Resolução:",
-      "scale": "Escala",
-      "size": "Tamanho",
-      "submit": "Enviar",
-      "usersize": "Medidas do usuário",
-      "wait": "Aguarde"
     },
     "redlining": {
       "border": "Borda",

--- a/static/translations/pt-PT.json
+++ b/static/translations/pt-PT.json
@@ -11,14 +11,12 @@
         "MapExport": "Exportar Mapa",
         "MapFilter": "",
         "Print": "Imprimir",
-        "RasterExport": "Exportar Raster",
         "Reports": "",
         "Settings": "Configurações",
         "Share": "Partilhar Link",
         "ThemeSwitcher": "Tema",
         "AttributeTable": "Tabela de Atributos",
         "Cyclomedia": "Cyclomedia",
-        "DxfExport": "Exportar DXF",
         "FeatureForm": "Formulário de Recurso",
         "FeatureSearch": "Pesquisa de Recurso",
         "GeometryDigitizer": "",
@@ -140,11 +138,6 @@
       "login": "Iniciar Sessão",
       "scalehint": "Dica de Escala",
       "title": "Cyclomedia"
-    },
-    "dxfexport": {
-      "layers": "Camadas",
-      "selectinfo": "Arraste um retângulo ao redor da região para exportar...",
-      "symbologyscale": "Escala de Símbolos"
     },
     "editing": {
       "add": "Adicionar",
@@ -378,6 +371,10 @@
     },
     "print": {
       "atlasfeature": "Recurso do Atlas",
+      "download": "",
+      "download_as_onepdf": "",
+      "download_as_onezip": "",
+      "download_as_single": "",
       "format": "Formato",
       "grid": "Grelha",
       "layout": "Esquema",
@@ -387,25 +384,18 @@
       "nolayouts": "O tema selecionado não suporta a impressão",
       "notheme": "Nenhum tema selecionado",
       "output": "Saída",
+      "overlap": "",
       "pickatlasfeature": "Escolher Recurso do Atlas",
       "resolution": "Resolução",
       "rotation": "Rotação",
       "save": "",
       "scale": "Escala",
+      "series": "",
       "submit": "Imprimir",
       "wait": "Por favor, aguarde..."
     },
     "qtdesignerform": {
       "loading": "A carregar..."
-    },
-    "rasterexport": {
-      "format": "Formato:",
-      "resolution": "Resolução:",
-      "scale": "Escala:",
-      "size": "Tamanho:",
-      "submit": "Enviar",
-      "usersize": "Tamanho Personalizado",
-      "wait": "Por favor, aguarde..."
     },
     "redlining": {
       "border": "Fronteira",

--- a/static/translations/ro-RO.json
+++ b/static/translations/ro-RO.json
@@ -11,14 +11,12 @@
         "MapExport": "",
         "MapFilter": "",
         "Print": "Tipărire",
-        "RasterExport": "Export Raster",
         "Reports": "",
         "Settings": "Setări",
         "Share": "Trimite Link",
         "ThemeSwitcher": "Hărți tematice",
         "AttributeTable": "Tabela de atribute",
         "Cyclomedia": "Cyclomedia",
-        "DxfExport": "Export DXF",
         "FeatureForm": "Editare atribute",
         "FeatureSearch": "",
         "GeometryDigitizer": "",
@@ -140,11 +138,6 @@
       "login": "Autentificare",
       "scalehint": "Înregistrările sunt vizibile pe hartă doar la scara 1:{0} sau mai mare",
       "title": "Informații Cyclomedia"
-    },
-    "dxfexport": {
-      "layers": "Straturi",
-      "selectinfo": "Încadrați într-un dreptunghi zona de exportat..",
-      "symbologyscale": "Scara simbolurilor"
     },
     "editing": {
       "add": "Adaugă",
@@ -378,6 +371,10 @@
     },
     "print": {
       "atlasfeature": "Obiect în atlas",
+      "download": "",
+      "download_as_onepdf": "",
+      "download_as_onezip": "",
+      "download_as_single": "",
       "format": "",
       "grid": "Grid",
       "layout": "Șablon",
@@ -387,25 +384,18 @@
       "nolayouts": "Această temă nu permite tipărirea",
       "notheme": "Nicio temă selectată",
       "output": "Rezultat tipărire",
+      "overlap": "",
       "pickatlasfeature": "Selectare din stratul {0}...",
       "resolution": "Rezoluție",
       "rotation": "Rotație",
       "save": "",
       "scale": "Scară",
+      "series": "",
       "submit": "Tipărește",
       "wait": "Vă rugăm așteptați..."
     },
     "qtdesignerform": {
       "loading": "Formularul se încarcă"
-    },
-    "rasterexport": {
-      "format": "Format",
-      "resolution": "Rezoluție",
-      "scale": "Scara",
-      "size": "Dimensiuni",
-      "submit": "Export",
-      "usersize": "Selectați în hartă...",
-      "wait": "Vă rugăm așteptați..."
     },
     "redlining": {
       "border": "Margine",

--- a/static/translations/ru-RU.json
+++ b/static/translations/ru-RU.json
@@ -11,14 +11,12 @@
         "MapExport": "экспортировать карту",
         "MapFilter": "",
         "Print": "Печать",
-        "RasterExport": "Экспорт в растровый Формат бумаги",
         "Reports": "",
         "Settings": "",
         "Share": "Поделиться ссылкой",
         "ThemeSwitcher": "Тема",
         "AttributeTable": "",
         "Cyclomedia": "",
-        "DxfExport": "Экспорт в DXF",
         "FeatureForm": "",
         "FeatureSearch": "",
         "GeometryDigitizer": "",
@@ -140,11 +138,6 @@
       "login": "",
       "scalehint": "",
       "title": ""
-    },
-    "dxfexport": {
-      "layers": "",
-      "selectinfo": "Для экспорта обведите регион многоугольником...",
-      "symbologyscale": "Масштаб символики:"
     },
     "editing": {
       "add": "",
@@ -378,6 +371,10 @@
     },
     "print": {
       "atlasfeature": "",
+      "download": "",
+      "download_as_onepdf": "",
+      "download_as_onezip": "",
+      "download_as_single": "",
       "format": "Формат бумаги",
       "grid": "Сетка",
       "layout": "Формат бумаги",
@@ -387,25 +384,18 @@
       "nolayouts": "Выбранная тема не поддерживает печать",
       "notheme": "Тема не выбрана",
       "output": "",
+      "overlap": "",
       "pickatlasfeature": "",
       "resolution": "Разрешение",
       "rotation": "Поворот",
       "save": "",
       "scale": "Масштаб",
+      "series": "",
       "submit": "Печать",
       "wait": ""
     },
     "qtdesignerform": {
       "loading": ""
-    },
-    "rasterexport": {
-      "format": "Формат бумаги:",
-      "resolution": "Разрешение:",
-      "scale": "",
-      "size": "",
-      "submit": "",
-      "usersize": "",
-      "wait": ""
     },
     "redlining": {
       "border": "Граница",

--- a/static/translations/sv-SE.json
+++ b/static/translations/sv-SE.json
@@ -11,14 +11,12 @@
         "MapExport": "Exportera karta",
         "MapFilter": "",
         "Print": "Skriv ut",
-        "RasterExport": "Raster Export",
         "Reports": "",
         "Settings": "",
         "Share": "Dela länk",
         "ThemeSwitcher": "Tema",
         "AttributeTable": "",
         "Cyclomedia": "",
-        "DxfExport": "DXF Export",
         "FeatureForm": "",
         "FeatureSearch": "",
         "GeometryDigitizer": "",
@@ -140,11 +138,6 @@
       "login": "",
       "scalehint": "",
       "title": ""
-    },
-    "dxfexport": {
-      "layers": "",
-      "selectinfo": "Rita en rektangel runt området som ska exporteras...",
-      "symbologyscale": "Symbolskala:"
     },
     "editing": {
       "add": "",
@@ -378,6 +371,10 @@
     },
     "print": {
       "atlasfeature": "",
+      "download": "",
+      "download_as_onepdf": "",
+      "download_as_onezip": "",
+      "download_as_single": "",
       "format": "Format",
       "grid": "Rutnät",
       "layout": "Layout:",
@@ -387,25 +384,18 @@
       "nolayouts": "Valt tema stöder inte utskrift",
       "notheme": "Inget tema valt",
       "output": "Utskrift",
+      "overlap": "",
       "pickatlasfeature": "",
       "resolution": "Upplösning",
       "rotation": "Rotation",
       "save": "",
       "scale": "Skala",
+      "series": "",
       "submit": "Skriv ut",
       "wait": "Vänta..."
     },
     "qtdesignerform": {
       "loading": ""
-    },
-    "rasterexport": {
-      "format": "Format:",
-      "resolution": "Upplösning:",
-      "scale": "",
-      "size": "",
-      "submit": "",
-      "usersize": "",
-      "wait": ""
     },
     "redlining": {
       "border": "Kant",

--- a/static/translations/tr-TR.json
+++ b/static/translations/tr-TR.json
@@ -11,14 +11,12 @@
         "MapExport": "Dışarıya ver",
         "MapFilter": "Harita Filtresi",
         "Print": "Yazdır",
-        "RasterExport": "Resim Olarak Kaydet",
         "Reports": "",
         "Settings": "Ayarlar",
         "Share": "Bağlantı Paylaş",
         "ThemeSwitcher": "Tema",
         "AttributeTable": "Öznitelik Tablosu",
         "Cyclomedia": "Siklomedya",
-        "DxfExport": "DXF'e Veri Aktar",
         "FeatureForm": "Obje Formu",
         "FeatureSearch": "Obje Arama",
         "GeometryDigitizer": "Geometri Sayısallaştırıcı",
@@ -140,11 +138,6 @@
       "login": "Login",
       "scalehint": "The recordings are only visible on the map below scale 1:{0}.",
       "title": "Cyclomedia Viewer"
-    },
-    "dxfexport": {
-      "layers": "Katmanlar",
-      "selectinfo": "Export edilecek alana bir dikdörtgen çizin...",
-      "symbologyscale": "Sembol Ölçeği:"
     },
     "editing": {
       "add": "Ekle",
@@ -378,6 +371,10 @@
     },
     "print": {
       "atlasfeature": "Atlas Objesi",
+      "download": "",
+      "download_as_onepdf": "",
+      "download_as_onezip": "",
+      "download_as_single": "",
       "format": "Format",
       "grid": "Karelaj",
       "layout": "Yazdırma düzeni",
@@ -387,25 +384,18 @@
       "nolayouts": "Seçili tema yazdırma işlemini desteklemiyor",
       "notheme": "Tema seçilmedi",
       "output": "Yazıcı çıktısı",
+      "overlap": "",
       "pickatlasfeature": "Katmandan seçiniz: {0}...",
       "resolution": "Çözünürlük",
       "rotation": "Döndürme",
       "save": "",
       "scale": "Ölçek:",
+      "series": "",
       "submit": "Yazdır",
       "wait": "Lütfen bekleyiniz..."
     },
     "qtdesignerform": {
       "loading": "Form yükleniyor..."
-    },
-    "rasterexport": {
-      "format": "Format:",
-      "resolution": "Çözünürlük:",
-      "scale": "Ölçek",
-      "size": "Boyut",
-      "submit": "Ver",
-      "usersize": "Haritadan seç...",
-      "wait": "Lütfen bekleyiniz..."
     },
     "redlining": {
       "border": "Sınır",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1589,6 +1589,20 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@pdf-lib/standard-fonts@^1.0.0":
+  version "1.0.0"
+  resolved "https://artifactory.intra.swm.de/artifactory/api/npm/npmjs-registry/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz#8ba691c4421f71662ed07c9a0294b44528af2d7f"
+  integrity sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==
+  dependencies:
+    pako "^1.0.6"
+
+"@pdf-lib/upng@^1.0.1":
+  version "1.0.1"
+  resolved "https://artifactory.intra.swm.de/artifactory/api/npm/npmjs-registry/@pdf-lib/upng/-/upng-1.0.1.tgz#7dc9c636271aca007a9df4deaf2dd7e7960280cb"
+  integrity sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==
+  dependencies:
+    pako "^1.0.10"
+
 "@petamoriken/float16@^3.4.7":
   version "3.8.0"
   resolved "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.8.0.tgz"
@@ -6063,7 +6077,7 @@ painterro@^1.2.87:
     core-js "^3.11.0"
     dom-to-image "^2.6.0"
 
-pako@1.0.11, pako@^1.0.0, pako@~1.0.2:
+pako@1.0.11, pako@^1.0.0, pako@^1.0.10, pako@^1.0.11, pako@^1.0.6, pako@~1.0.2:
   version "1.0.11"
   resolved "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
@@ -6183,6 +6197,16 @@ pbf@^3.2.1:
   dependencies:
     ieee754 "^1.1.12"
     resolve-protobuf-schema "^2.1.0"
+
+pdf-lib@^1.17.1:
+  version "1.17.1"
+  resolved "https://artifactory.intra.swm.de/artifactory/api/npm/npmjs-registry/pdf-lib/-/pdf-lib-1.17.1.tgz#9e7dd21261a0c1fb17992580885b39e7d08f451f"
+  integrity sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==
+  dependencies:
+    "@pdf-lib/standard-fonts" "^1.0.0"
+    "@pdf-lib/upng" "^1.0.1"
+    pako "^1.0.11"
+    tslib "^1.11.1"
 
 pdfjs-dist@^4.6.82:
   version "4.6.82"
@@ -7652,7 +7676,7 @@ tslib@2.6.2, tslib@^2.0.0, tslib@^2.0.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
-tslib@^1.9.0:
+tslib@^1.11.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==


### PR DESCRIPTION
This pull request updates the qwc2 submodule and the corresponding config files. The "displayPrintSeries" flag is set to true so that the print series feature can be tested easily. I am not sure if this feature should be enabled or disabled in the demo app by default. I also do not know about your upgrade policy for the yarn.lock file so I only ran the "yarn install" command which added additional versions for some dependencies.